### PR TITLE
extraction of embedded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build
 MANIFEST
 *.DS_Store
 psd_tools.egg-info
+*~
+\#*
+\.\#*

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -13,4 +13,5 @@ Contributors
 * Vladimir Timofeev;
 * Evgeny Kopylov;
 * Carlton P. Taylor;
-* Joey Gentry.
+* Joey Gentry;
+* Volker Braun.

--- a/src/psd_tools/__init__.py
+++ b/src/psd_tools/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
-from .user_api import PSDImage, Layer, Group, BBox
+from .user_api import PSDImage, Layer, Group, BBox, Embedded
 from .version import __version__
 

--- a/src/psd_tools/decoder/linked_layer.py
+++ b/src/psd_tools/decoder/linked_layer.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals, print_function
+import warnings
+import io
+import struct
+
+from psd_tools.utils import read_fmt, read_pascal_string, read_unicode_string
+from psd_tools.debug import pretty_namedtuple
+
+LinkedLayerCollection = pretty_namedtuple('LinkedLayerCollection', 'linked_list ')
+_LinkedLayer = pretty_namedtuple('LinkedLayer',
+                               'version unique_id filename filetype creator decoded uuid')
+
+
+class LinkedLayer(_LinkedLayer):
+
+    def __repr__(self):
+        return "LinkedLayer(filename='%s', size=%s)" % (self.filename, len(self.decoded))
+
+    def _repr_pretty_(self, p, cycle):
+        if cycle:
+            p.text("LinkedLayer(...)")
+        else:
+            with p.group(1, "LinkedLayer(", ")"):
+                p.breakable()
+                p.text("filename='%s', ", self.filename)
+                p.breakable()
+                p.text("size=%s, ", len(self.decoded))
+                p.breakable()
+                p.text("unique_id=%s, ", self.unique_id)
+                p.breakable()
+                p.text("type='%s', ", self.filetype)
+                p.breakable()
+                p.text("creator='%s', ", self.creator)
+
+
+def decode(data):
+    """
+    Reads and decodes info about linked layers.
+
+    These are embedded files (embedded smart objects). But Adobe calls
+    them "linked layers", so we'll follow that nomenclature. Note that
+    non-embedded smart objects are not included here.
+    """
+    fp = io.BytesIO(data)
+    position = 0
+    layers = []
+    while True:
+        length_buf = fp.read(8)
+        if not length_buf:
+            break   # end of file
+        length = struct.unpack('>Q', length_buf)[0]
+        liFD, version = read_fmt('4s I', fp)
+        if liFD != b'liFD':
+            warnings.warn('unknown layer type')
+            break
+        unique_id = read_pascal_string(fp, 'ascii')
+        filename = read_unicode_string(fp)
+        filetype, creator, remaining_length, file_open_descriptor = read_fmt('4s 4s Q B', fp)
+        filetype = str(filetype)
+        if not file_open_descriptor:
+            if remaining_length + 198 != length:
+                warnings.warn('record length mismatch')
+        else:
+            # WTF is this, Adobe: "variable length: Descriptor of open parameters"
+            warnings.warn('decoding of file open descriptor not implemented')
+            size = length - remaining_length - 198 + 4   # undocumented guess
+            fp.read(size)
+        decoded = fp.read(remaining_length)
+        uuid = read_unicode_string(fp)
+        layers.append(
+            LinkedLayer(version, unique_id, filename, filetype, creator, decoded, uuid)
+        )
+        # Each layer is padded to start at 4-byte boundary
+        position += length
+        pad = -position % 4
+        fp.read(pad)
+        position += pad
+    return LinkedLayerCollection(layers)
+

--- a/src/psd_tools/decoder/linked_layer.py
+++ b/src/psd_tools/decoder/linked_layer.py
@@ -49,7 +49,7 @@ def decode(data):
         length_buf = fp.read(8)
         if not length_buf:
             break   # end of file
-        length = struct.unpack('>Q', length_buf)[0]
+        length = struct.unpack(str('>Q'), length_buf)[0]
         liFD, version = read_fmt('4s I', fp)
         if liFD != b'liFD':
             warnings.warn('unknown layer type')

--- a/src/psd_tools/decoder/linked_layer.py
+++ b/src/psd_tools/decoder/linked_layer.py
@@ -10,7 +10,7 @@ from psd_tools.decoder.actions import decode_descriptor
 
 LinkedLayerCollection = pretty_namedtuple('LinkedLayerCollection', 'linked_list ')
 _LinkedLayer = pretty_namedtuple('LinkedLayer',
-                               'version unique_id filename filetype creator decoded')
+                                 'version unique_id filename filetype file_open_descriptor creator decoded')
 
 
 class LinkedLayer(_LinkedLayer):
@@ -63,9 +63,11 @@ def decode(data):
             # Does not seem to contain any useful information
             undocumented_integer = read_fmt("I", fp)
             file_open_descriptor = decode_descriptor(None, fp)
+        else:
+            file_open_descriptor = None
         decoded = fp.read(filelength)
         layers.append(
-            LinkedLayer(version, unique_id, filename, filetype, creator, decoded)
+            LinkedLayer(version, unique_id, filename, filetype, file_open_descriptor, creator, decoded)
         )
         # Undocumented extra field
         if version == 5:

--- a/src/psd_tools/decoder/linked_layer.py
+++ b/src/psd_tools/decoder/linked_layer.py
@@ -10,7 +10,8 @@ from psd_tools.decoder.actions import decode_descriptor
 
 LinkedLayerCollection = pretty_namedtuple('LinkedLayerCollection', 'linked_list ')
 _LinkedLayer = pretty_namedtuple('LinkedLayer',
-                                 'version unique_id filename filetype file_open_descriptor creator decoded')
+                                 'version unique_id filename filetype file_open_descriptor '
+                                 'creator decoded uuid')
 
 
 class LinkedLayer(_LinkedLayer):
@@ -66,12 +67,15 @@ def decode(data):
         else:
             file_open_descriptor = None
         decoded = fp.read(filelength)
-        layers.append(
-            LinkedLayer(version, unique_id, filename, filetype, file_open_descriptor, creator, decoded)
-        )
         # Undocumented extra field
         if version == 5:
             uuid = read_unicode_string(fp)
+        else:
+            uuid = None
+        layers.append(
+            LinkedLayer(version, unique_id, filename, filetype, file_open_descriptor,
+                        creator, decoded, uuid)
+        )
         # Gobble up anything that we don't know how to decode
         expected_position = start + 8 + length      # first 8 bytes contained the length
         if expected_position != fp.tell():

--- a/src/psd_tools/decoder/tagged_blocks.py
+++ b/src/psd_tools/decoder/tagged_blocks.py
@@ -229,3 +229,11 @@ def _decode_vector_origination_data(data):
         return data
 
     return VectorOriginationData(ver, descr_ver, vector_origination_data)
+
+
+@register(TaggedBlock.LINKED_LAYER1)
+@register(TaggedBlock.LINKED_LAYER2)
+@register(TaggedBlock.LINKED_LAYER3)
+def _decode_linked_layer(data):
+    from psd_tools.decoder.linked_layer import decode
+    return decode(data)

--- a/src/psd_tools/user_api/__init__.py
+++ b/src/psd_tools/user_api/__init__.py
@@ -2,3 +2,4 @@
 from __future__ import absolute_import
 
 from psd_tools.user_api.psd_image import PSDImage, Layer, Group, BBox
+from psd_tools.user_api.embedded import Embedded

--- a/src/psd_tools/user_api/embedded.py
+++ b/src/psd_tools/user_api/embedded.py
@@ -60,7 +60,7 @@ class Embedded(object):
 
     def save_as_png(self, filename=None):
         """
-        Save embedded file as SVG
+        Save embedded file as PNG
 
         Requires inkscape to convert the file.
         """

--- a/src/psd_tools/user_api/embedded.py
+++ b/src/psd_tools/user_api/embedded.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals, division
+
+import os
+import logging
+import contextlib
+
+
+class Embedded(object):
+    """Embedded Smart Object"""
+
+    def __repr__(self):
+        return "<psd_tools.Embedded: %s, %s bytes>" % (
+            self.filename,
+            len(self.get())
+        )
+
+    def __init__(self, linked_layer):
+        self._layer = linked_layer
+        self.filename = linked_layer.filename.strip('\0x0')
+        self.unique_id = linked_layer.unique_id
+
+    def preferred_extension(self):
+        filetype = self._layer.filetype   # 4 chars: 'png ', 'PDF ', ...
+        return filetype.lower().strip()
+
+    def get(self):
+        """
+        Get the embedded file content
+        """
+        return self._layer.decoded
+
+    def save(self, filename=None):
+        """
+        Save the embedded file
+        """
+        if filename is None:
+            filename = self.filename
+        with open(filename, 'wb') as f:
+            f.write(self.get())
+
+    def _inkscape(self, *args):
+        """Convert using inkscape"""
+        import subprocess
+        subprocess.check_call(['inkscape', '-z'] + list(args))
+
+    @contextlib.contextmanager
+    def _tmp_file(self):
+        """Context manager for accessing the content through a temporary file"""
+        import tempfile
+        tmp_dir = tempfile.mkdtemp()
+        tmp_file = os.path.join(tmp_dir, self.filename)
+        try:
+            self.save(tmp_file)
+            yield tmp_file
+        finally:
+            if os.path.exists(tmp_file):
+                os.remove(tmp_file)
+            os.rmdir(tmp_dir)
+
+    def save_as_png(self, filename=None):
+        """
+        Save embedded file as SVG
+
+        Requires inkscape to convert the file.
+        """
+        if filename is None:
+            filename = self.filename
+        with self._tmp_file() as src:
+            self._inkscape('--file', src, '--export-png', filename)
+
+    def save_as_svg(self, filename=None):
+        """
+        Save embedded file as PNG
+
+        Requires inkscape to convert the file.
+        """
+        if filename is None:
+            filename = self.filename
+        with self._tmp_file() as src:
+            self.save(src)
+            self._inkscape('--file', src, '--export-plain-svg', filename)
+

--- a/src/psd_tools/user_api/embedded.py
+++ b/src/psd_tools/user_api/embedded.py
@@ -12,7 +12,7 @@ class Embedded(object):
     def __repr__(self):
         return "<psd_tools.Embedded: %s, %s bytes>" % (
             self.filename,
-            len(self.get())
+            len(self.data)
         )
 
     def __init__(self, linked_layer):
@@ -24,9 +24,10 @@ class Embedded(object):
         filetype = self._layer.filetype   # 4 chars: 'png ', 'PDF ', ...
         return filetype.lower().strip()
 
-    def get(self):
+    @property
+    def data(self):
         """
-        Get the embedded file content
+        The embedded file content
         """
         return self._layer.decoded
 
@@ -37,7 +38,7 @@ class Embedded(object):
         if filename is None:
             filename = self.filename
         with open(filename, 'wb') as f:
-            f.write(self.get())
+            f.write(self.data)
 
     def _inkscape(self, *args):
         """Convert using inkscape"""

--- a/tests/test_placed_layer.py
+++ b/tests/test_placed_layer.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import os
+
 from psd_tools import PSDImage, BBox
 from psd_tools.constants import TaggedBlock
-from .utils import decode_psd
+from .utils import decode_psd, DATA_PATH
 
 
 def test_placed_layer():
@@ -42,3 +44,12 @@ def test_userapi_placed_layers():
     layer2 = img.layers[2]
     assert layer2.placed_layer_size == (64, 64)
     assert layer2.transform_bbox == BBox(x1=96.0, y1=96.0, x2=160.0, y2=160.0)
+
+
+def test_embedded():
+    # This file contains both an embedded and linked png
+    psd = PSDImage.load(os.path.join(DATA_PATH, 'placedLayer.psd'))
+    embedded = psd.embedded[0]
+    assert embedded.filename == 'linked-layer.png'
+    with open(os.path.join(DATA_PATH, 'linked-layer.png'), 'rb') as f:
+        assert embedded.get() == f.read()

--- a/tests/test_placed_layer.py
+++ b/tests/test_placed_layer.py
@@ -52,4 +52,4 @@ def test_embedded():
     embedded = psd.embedded[0]
     assert embedded.filename == 'linked-layer.png'
     with open(os.path.join(DATA_PATH, 'linked-layer.png'), 'rb') as f:
-        assert embedded.get() == f.read()
+        assert embedded.data == f.read()


### PR DESCRIPTION
Access for embedded files, these are called embedded smart objects by Adobe I think.

I'm using this to save embbedded Illustrator files as SVG without using any Adobe product using

    for i, emb in enumerate(psd.embedded):
        emb.save_as_svg('/tmp/psdexport/icon-{0}.svg'.format(i))
