### PR TITLE
monkey patch for PIL 1.1.7 for CMYK files

### DIFF
--- a/src/psd_tools/user_api/pil_support.py
+++ b/src/psd_tools/user_api/pil_support.py
@@ -116,6 +116,11 @@ def _merge_bands(bands, color_mode, size, icc_profile):
         merged_image = Image.merge('RGB', [bands[key] for key in 'RGB'])
     elif color_mode == ColorMode.CMYK:
         merged_image = Image.merge('CMYK', [bands[key] for key in 'CMYK'])
+
+        # Monkey patch some versions of PIL that lack the alias tobytes
+        if not hasattr(merged_image, 'tobytes'):
+            merged_image.tobytes = merged_image.tostring
+
         # colors are inverted in Photoshop CMYK images; invert them back
         merged_image = frombytes('CMYK', size, merged_image.tobytes(), 'raw', 'CMYK;I')
     elif color_mode == ColorMode.GRAYSCALE:

--- a/src/psd_tools/user_api/pil_support.py
+++ b/src/psd_tools/user_api/pil_support.py
@@ -21,6 +21,14 @@ except ImportError:
     ImageCms = None
 
 
+def tobytes(image):
+    # Some versions of PIL are missing the tobytes alias for tostring
+    if hasattr(image, 'tobytes'):
+        return image.tobytes()
+    else:
+        return image.tostring()
+
+
 def extract_layer_image(decoded_data, layer_index):
     """
     Converts a layer from the ``decoded_data`` to a PIL image.
@@ -116,13 +124,9 @@ def _merge_bands(bands, color_mode, size, icc_profile):
         merged_image = Image.merge('RGB', [bands[key] for key in 'RGB'])
     elif color_mode == ColorMode.CMYK:
         merged_image = Image.merge('CMYK', [bands[key] for key in 'CMYK'])
-
-        # Monkey patch some versions of PIL that lack the alias tobytes
-        if not hasattr(merged_image, 'tobytes'):
-            merged_image.tobytes = merged_image.tostring
-
+        merged_bytes = tobytes(merged_image)
         # colors are inverted in Photoshop CMYK images; invert them back
-        merged_image = frombytes('CMYK', size, merged_image.tobytes(), 'raw', 'CMYK;I')
+        merged_image = frombytes('CMYK', size, merged_bytes, 'raw', 'CMYK;I')
     elif color_mode == ColorMode.GRAYSCALE:
         merged_image = bands['L']
     else:


### PR DESCRIPTION
Version 1.1.7 of PIL seems to lack tobytes. I think someone messed up on the 2 to 3 conversion. Unfortunately I can't upgrade right away...

I didn't want to patch PIL globally so just doing it on the object